### PR TITLE
CI: Add apt dependencies to the Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev
       - name: Set up latest Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Without this, patron can not be installed, and we can not get to the publish part of the Workflow.